### PR TITLE
Format message body as string for non-200's

### DIFF
--- a/src/opentelemetry_exporter.erl
+++ b/src/opentelemetry_exporter.erl
@@ -51,7 +51,7 @@ export(Tab, Resource, #state{protocol=http_protobuf,
         {ok, {{_, Code, _}, _, _}} when Code >= 200 andalso Code =< 202 ->
             ok;
         {ok, {{_, Code, _}, _, Message}} ->
-            ?LOG_INFO("error response from service exported to status=~p ~p",
+            ?LOG_INFO("error response from service exported to status=~p ~s",
                       [Code, Message]),
             error;
         {error, Reason} ->


### PR DESCRIPTION
In Elixir `~p` will just print a list of numbers in the log.