### PR TITLE
Add support for tuple attr values

### DIFF
--- a/src/opentelemetry_exporter.erl
+++ b/src/opentelemetry_exporter.erl
@@ -164,6 +164,9 @@ to_attributes([{Key, Value} | Rest], Acc) when is_boolean(Value) ->
 to_attributes([{Key, Value} | Rest], Acc) when is_map(Value) ->
     to_attributes(Rest, [#{key => to_binary(Key),
                            values => #{value => {kvlist_value, maps:to_list(Value)}}} | Acc]);
+to_attributes([{Key, Value} | Rest], Acc) when is_tuple(Value) ->
+    to_attributes(Rest, [#{key => to_binary(Key),
+                           values => #{value => {array_value, tuple_to_list(Value)}}} | Acc]);
 to_attributes([{Key, Value} | Rest], Acc) when is_list(Value) ->
     case is_proplist(Value) of
         true ->

--- a/test/opentelemetry_exporter_SUITE.erl
+++ b/test/opentelemetry_exporter_SUITE.erl
@@ -110,7 +110,8 @@ span_round_trip(_Config) ->
               attributes = [
                   {<<"attr-2">>, <<"value-2">>},
                   {<<"map-key-1">>, #{<<"map-key-1">> => 123}},
-                  {<<"proplist-key-1">>, [{proplistkey1, 456}, {<<"proplist-key-2">>, 9.345}]}
+                  {<<"proplist-key-1">>, [{proplistkey1, 456}, {<<"proplist-key-2">>, 9.345}]},
+                  {<<"tuple-key-1">>, {a, 123, [456, {1, 2}]}}
                 ],
               status = #status{code='Ok',
                                message = <<"">>},
@@ -180,7 +181,8 @@ verify_export(Config) ->
                                     {<<"attr-2">>, <<"value-2">>},
                                     {<<"map-key-1">>, #{<<"map-key-1">> => 123}},
                                     {<<"proplist-key-1">>, [{proplistkey1, 456}, {<<"proplist-key-2">>, 9.345}]},
-                                    {<<"list-key-1">>, [listkey1, 123, <<"list-value-3">>]}
+                                    {<<"list-key-1">>, [listkey1, 123, <<"list-value-3">>]},
+                                    {<<"tuple-key-1">>, {a, 123, [456, {1, 2}]}}
                                    ]},
     true = ets:insert(Tid, ChildSpan),
 


### PR DESCRIPTION
I noticed we missed support for tuple attribute values. This should remove yet another value type to inspect.